### PR TITLE
Change of LLM model from Gemini 1.5 to Gemini 2.0

### DIFF
--- a/[GitHub]_ABCDs_Detector.ipynb
+++ b/[GitHub]_ABCDs_Detector.ipynb
@@ -207,9 +207,10 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 2,
+      "execution_count": null,
       "metadata": {
-        "id": "myojeXOC0UYJ"
+        "id": "myojeXOC0UYJ",
+        "cellView": "form"
       },
       "outputs": [],
       "source": [
@@ -299,7 +300,7 @@
         "\n",
         "# @markdown ### LLM Configuration\n",
         "\n",
-        "LLM_NAME = \"gemini-1.5-pro-002\"  # @param {type:\"string\"}\n",
+        "LLM_NAME = \"gemini-2.0-flash-001\"  # @param {type:\"string\"}\n",
         "VIDEO_SIZE_LIMIT_MB = 50  # @param {type:\"number\"}\n",
         "MAX_OUTPUT_TOKENS = 8192  # @param {type:\"number\"}\n",
         "TEMPERATURE = 1  # @param {type:\"number\"}\n",
@@ -350,7 +351,7 @@
       "metadata": {
         "id": "g7ehWDRtQxjX"
       },
-      "execution_count": 3,
+      "execution_count": null,
       "outputs": []
     },
     {
@@ -364,7 +365,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 4,
+      "execution_count": null,
       "metadata": {
         "id": "Ovcu5_OXGHy_"
       },


### PR DESCRIPTION
Upgrade of the model **from** gemini-1.5-pro-002 **to** gemini-2.0-flash-001 due to upcoming retirement date of Gemini 1.5. 

For reference: https://cloud.google.com/vertex-ai/generative-ai/docs/learn/model-versions
