### PR TITLE
fix: handle None values for Gemini parsed response and features_to_evaluate argument

### DIFF
--- a/gcp_api_services/gemini_api_service.py
+++ b/gcp_api_services/gemini_api_service.py
@@ -96,6 +96,13 @@ class GeminiAPIService:
             config=generate_content_config,
         )
 
+        if response.parsed is None:
+          print("WARNING: response.parsed is None. Returning empty list.")
+          try:
+            print(f"DEBUG: Raw response text: {response.text}")
+          except Exception as e:
+            print(f"DEBUG: Could not print raw response text: {e}")
+          return []
         return response.parsed
       except ResourceExhausted as ex:
         print(f"QUOTA RETRY: {this_retry + 1}. ERROR {str(ex)} ...")
@@ -134,6 +141,7 @@ class GeminiAPIService:
           )
           # Raise exception for non-retriable errors
           raise
+    return []
 
   def execute_gemini_pro(
       self, config: Configuration, prompt: str, params: LLMParameters

--- a/utils.py
+++ b/utils.py
@@ -48,7 +48,7 @@ def build_abcd_params_config(args: any) -> Configuration:
       use_llms=args.use_llms,
       run_long_form_abcd=args.run_long_form_abcd,
       run_shorts=args.run_shorts,
-      features_to_evaluate=args.features_to_evaluate.split(","),
+      features_to_evaluate=args.features_to_evaluate.split(",") if args.features_to_evaluate else [], # Handle None features_to_evaluate
       creative_provider_type=args.creative_provider_type,
       verbose=args.verbose,
   )


### PR DESCRIPTION
## Description

This PR addresses two potential crash issues when running the ABCD detector:

1. **Gemini API Service (`gcp_api_services/gemini_api_service.py`)**:
   - **Issue**: If the Gemini model fails to output structured JSON in the expected schema (e.g., due to safety filters or generation instability), `response.parsed` evaluates to `None`. This causes subsequent processing to fail with attribute errors.
   - **Fix**: Added a check for `response.parsed is None` to log a warning with the raw response text for debugging, and gracefully return an empty list `[]` to avoid halting the execution.

2. **CLI Parameter Parsing (`utils.py`)**:
   - **Issue**: When running the script without specifying the optional command-line argument `-features_to_evaluate` (or `-fte`), `args.features_to_evaluate` defaults to `None`. Attempting to call `.split(",")` on it causes an `AttributeError`.
   - **Fix**: Added a safe check to fallback to an empty list `[]` when the argument is not provided.

## Test Status
- Verified that the application runs successfully without crashes when the `features_to_evaluate` parameter is omitted.
- Verified that warnings are properly logged with raw outputs when model parsing fails, instead of throwing hard exceptions.
